### PR TITLE
Update - do not prefix login path IF WINDOWS

### DIFF
--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -284,7 +284,7 @@ class Connection(ConnectionBase):
         super(Connection, self).put_file(in_path, out_path)
         display.vvv("PUT %s TO %s" % (in_path, out_path), host=self._play_context.remote_addr)
 
-        if not if getattr(self._shell, "_IS_WINDOWS", False):
+        if not getattr(self._shell, "_IS_WINDOWS", False):
             out_path = self._prefix_login_path(out_path)
 
         if not os.path.exists(to_bytes(in_path, errors='surrogate_or_strict')):

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -284,7 +284,9 @@ class Connection(ConnectionBase):
         super(Connection, self).put_file(in_path, out_path)
         display.vvv("PUT %s TO %s" % (in_path, out_path), host=self._play_context.remote_addr)
 
-        out_path = self._prefix_login_path(out_path)
+        if not if getattr(self._shell, "_IS_WINDOWS", False):
+            out_path = self._prefix_login_path(out_path)
+
         if not os.path.exists(to_bytes(in_path, errors='surrogate_or_strict')):
             raise AnsibleFileNotFound(
                 "file or module does not exist: %s" % to_native(in_path))


### PR DESCRIPTION
Hello @felixfontein , thanks for being very helpful so far. Further testing my changes in the https://github.com/ansible/ansible/pull/67832, I have realized that changes in this PR are also needed to successfully copy files to windows containers via docker connection. Please let me know if you want me to open a new PR in the Ansible repo or if this fine. It would be great if changes from both these PRs get released in the next stable release 2.9.6 together.

##### SUMMARY
https://github.com/ansible/ansible/pull/67832 Fixes the need to run powershell modules on windows containers via docker connection. However, while running win_copy on windows containers, destination path is prefixed with `/` (doesnt work in the case of windows). The changes in this PR take care of bypassing that if OS is windows.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Docker connection plugin (lib/ansible/plugins/connection/docker.py)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
